### PR TITLE
Docstrings and type hints

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+plotting.py

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-plotting.py
+alpha_shapes.py

--- a/.idea/alpha_shapes.iml
+++ b/.idea/alpha_shapes.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (alpha_shapes)" project-jdk-type="Python SDK" />
+  <component name="PyCharmProfessionalAdvertiser">
+    <option name="shown" value="true" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/alpha_shapes.iml" filepath="$PROJECT_DIR$/.idea/alpha_shapes.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/alpha_shapes/alpha_shapes.py
+++ b/alpha_shapes/alpha_shapes.py
@@ -169,7 +169,7 @@ class Alpha_Shaper(Delaunay):
         """Eliminates redundant simplices and then sets appropriate mask.
 
         Returns:
-            alpha_opt: themost accurate alpha value based on minimal amount of simplices
+            alpha_opt: the most accurate alpha value based on minimal amount of simplices
             shape: shape after optimization
         """
         # We have to use at least N//3 triangles to connect N points

--- a/alpha_shapes/alpha_shapes.py
+++ b/alpha_shapes/alpha_shapes.py
@@ -187,26 +187,24 @@ class Alpha_Shaper(Delaunay):
         return self
 
 
-def _normalize_points(points: NDArray):
-    """
-    Normalize points to the unit square, centered at the origin.
+def _normalize_points(points: ArrayLike):
+    """Normalizes points to the unit square, centered at the origin.
 
-    Parameters:
-    -----------
+    Args:
     points: array-like, shape(N,2)
         coordinates of the points
 
     Returns:
-    --------
-    points: array, shape(N,2)
-        normalized coordinates of the points
+        points: array, shape(N,2)
+            normalized coordinates of the points
 
-    center: array, shape(2,)
-        coordinates of the center of the points
+        center: array, shape(2,)
+            coordinates of the center of the points
 
-    scale: array, shape(2,)
-        scale factors for the normalization
+        scale: array, shape(2,)
+            scale factors for the normalization
     """
+
     center = points.mean(axis=0)
     scale = np.ptp(points, axis=0)  # peak to peak distance
     normalized_points = (points - center) / scale
@@ -214,13 +212,17 @@ def _normalize_points(points: NDArray):
     return normalized_points, center, scale
 
 
-def _circumradius_sq(lengths):
-    r"""
-    Calculate the squared circumradius `r_c^2`,
-    where
-    r_c = \frac {abc}{4{\sqrt {s(s-a)(s-b)(s-c)}}}
-    See: `https://en.wikipedia.org/wiki/Circumscribed_circle`
+def _circumradius_sq(lengths: NDArray) -> NDArray:
+    """ Calculates the squared circumradius of triangle.
+    See more about it on: `https://en.wikipedia.org/wiki/Circumscribed_circle`.
+
+    Args:
+        lengths: contains lengths of triangle's sides.
+
+    Returns:
+        Contains values of squared circumradiuses.
     """
+
     lengths = np.asarray(lengths)
     s = np.sum(lengths) / 2
 
@@ -235,7 +237,16 @@ def _circumradius_sq(lengths):
 
 
 def _calculate_cirumradius_sq_of_triangle(x: ArrayLike, y: ArrayLike) -> NDArray:
-    """Calculates the squared circumradius of a triangle with coordinates x, y"""
+    """Calculates the squared circumradius of a triangle with coordinates x, y.
+
+    Args:
+        x: Contains all x values of triangle's points.
+        y: Contains all y values of triangle's points.
+
+    Returns:
+        NDArray with outcome from _circumradius_sq. It contains squared circumradius of internal triangle.
+    """
+
     dx = x - np.roll(x, shift=-1)
     dy = y - np.roll(y, shift=-1)
 
@@ -246,9 +257,14 @@ def _calculate_cirumradius_sq_of_triangle(x: ArrayLike, y: ArrayLike) -> NDArray
 def _simplex_to_triangle(smpl, tri) -> Polygon:
     """Creates internal triangles from given simplices.
 
-    Returns:
+    Args:
+        smpl: values of simplex.
+        tri: particular triangle.
 
+    Returns:
+        Polygon(shapely.geometry): contains points values of internal triangle.
     """
+
     x = tri.x[smpl]
     y = tri.y[smpl]
 

--- a/alpha_shapes/alpha_shapes.py
+++ b/alpha_shapes/alpha_shapes.py
@@ -1,5 +1,6 @@
 """
-Utility module for the calculation of alpha shapes
+This is a core module of package, which contains exceptions, functions
+and classes essential to printing figures.
 """
 
 import numpy as np
@@ -10,28 +11,37 @@ from shapely.ops import unary_union
 
 
 class AlphaException(Exception):
+    """Abstract class for all exceptions which will be raised within Alpha_Shaper class
+     directly or through Delaunay class"""
     pass
 
 
 class NotEnoughPoints(AlphaException):
+    """If instance of class Delaunay has less than 3 points, this exception will be raised"""
     pass
 
 
 class OptimizationFailure(AlphaException):
+    """If Alpha_Shaper instance can't cover all vertices, this exception will be raised"""
     pass
 
 
-class OptimizationWarnging(UserWarning):
+class OptimizationWarning(UserWarning):
+    """Warns user without interrupting the program"""
     pass
 
 
 class Delaunay(Triangulation):
     """
-    Visitor sublclass of matplotlib.tri.Triangulation.
-    Mimics scipy.spatial.Delaunay interface.
+    Delaunay is abstract class, which derives from matplotlib.tri.Triangulation.
+    It adds set of coordinates and essential methods.
     """
 
     def __init__(self, coords: NDArray):
+        """In try block function invokes __init__ method of class
+        Triangulation from matplotlib package and sends
+        to it default set of coordinates. If ValueError occurs,
+        function will tackle it."""
         try:
             super().__init__(x=coords[:, 0], y=coords[:, 1])
         except ValueError as e:
@@ -42,9 +52,11 @@ class Delaunay(Triangulation):
 
     @property
     def simplices(self):
+        """Creates simplices property essential to further operations"""
         return self.triangles
 
     def __len__(self):
+        """Returns amount of object's edges"""
         return self.simplices.shape[0]
 
 

--- a/alpha_shapes/plotting.py
+++ b/alpha_shapes/plotting.py
@@ -1,9 +1,19 @@
+"""This module contains mechanisms essential to printing figures.
+Functions receive sets of points from alpha_shapes and then plot appropriate shapes.
+This pattern is used in examples directory.
+"""
 import numpy as np
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 
 
 def plot_alpha_shape(ax, alpha_shape):
+    """Main-line function, which plots all sets of figure's points.
+
+    Args:
+        ax: Axes object received from matplotlib.subplots function
+        alpha_shape: set of points given by Alpha_Shaper._get_shape method
+    """
     try:
         geoms = alpha_shape.geoms
     except AttributeError:
@@ -14,9 +24,12 @@ def plot_alpha_shape(ax, alpha_shape):
 
 
 def _plot_polygon(ax, polygon):
-    """
-    Plot a polygon using matplotlib's PathPatch.
-    see https://stackoverflow.com/a/70533052/6060982
+    """Plots a polygon using matplotlib's PathPatch.
+    This thread on stackoverflow may be helpful https://stackoverflow.com/a/70533052/6060982.
+
+    Args:
+        ax: Axes object received from matplotlib.subplots function.
+        polygon: Polygon object (from shapely.geometry) nested in object returned by Alpha_Shaper._get_shape method.
     """
     xe, ye = polygon.exterior.xy
     exterior = Path(np.column_stack([xe, ye]))


### PR DESCRIPTION
Commits add docstrings and type hints for alpha_shapes.py and plotting.py files. Docstrings follow Google Style Python Docstrings pattern. Please, keep particular attention at type hints. I have checked it many times. However it was most challenging part of task, in few methods flow of object is quite advanced. Maybe I made a mistake somwhere.
I am open for hints and discussion. If need of amendments occurs, I will rewrite code.
Regards, Rhobar9